### PR TITLE
Propagate downstream errors up to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea*
 *.iml
 target/*
+.settings*
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <version.shade.maven.plugin>2.3</version.shade.maven.plugin>
         <version.unirest>1.4.9</version.unirest>
         <version.wildfly.swarm>2018.2.0</version.wildfly.swarm>
-        <version.xray.sdk-core>1.2.1</version.xray.sdk-core>
+        <version.xray.sdk-core>1.3.1</version.xray.sdk-core>
         <webapp.host>localhost</webapp.host>
         <webapp.port>8080</webapp.port>
     </properties>
@@ -65,6 +65,21 @@
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-xray-recorder-sdk-core</artifactId>
                 <version>${version.xray.sdk-core}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>aws-xray-recorder-sdk-apache-http</artifactId>
+              <version>${version.xray.sdk-core}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>aws-xray-recorder-sdk-aws-sdk</artifactId>
+              <version>${version.xray.sdk-core}</version>
+            </dependency>
+            <dependency>
+              <groupId>com.amazonaws</groupId>
+              <artifactId>aws-xray-recorder-sdk-aws-sdk-instrumentor</artifactId>
+              <version>${version.xray.sdk-core}</version>
             </dependency>
             <dependency>
                 <groupId>com.amazonaws</groupId>
@@ -117,6 +132,18 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-xray-recorder-sdk-core</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-xray-recorder-sdk-apache-http</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-xray-recorder-sdk-aws-sdk</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-xray-recorder-sdk-aws-sdk-instrumentor</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -300,4 +327,3 @@
     </profiles>
 
 </project>
-

--- a/src/main/java/org/aws/samples/compute/webapp/HealthEndpoint.java
+++ b/src/main/java/org/aws/samples/compute/webapp/HealthEndpoint.java
@@ -1,0 +1,27 @@
+package org.aws.samples.compute.webapp;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * @author Christoph Kassen
+ */
+@Path("/health")
+public class HealthEndpoint {
+
+    private static final Logger logger = LoggerFactory.getLogger(HealthEndpoint.class);
+
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public String get() {
+        logger.info("get");
+        String response = "OK";
+
+        return response;
+    }
+}

--- a/src/main/java/org/aws/samples/compute/webapp/MyApplication.java
+++ b/src/main/java/org/aws/samples/compute/webapp/MyApplication.java
@@ -18,6 +18,7 @@ public class MyApplication extends Application {
     public Set<Class<?>> getClasses() {
         Set<Class<?>> resources = new java.util.HashSet<>();
         resources.add(WebappController.class);
+        resources.add(HealthEndpoint.class);
         return resources;
     }
 

--- a/src/main/java/org/aws/samples/compute/webapp/WebappController.java
+++ b/src/main/java/org/aws/samples/compute/webapp/WebappController.java
@@ -2,11 +2,7 @@ package org.aws.samples.compute.webapp;
 
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.HttpResponse;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.util.EntityUtils;
 import com.amazonaws.xray.proxies.apache.http.HttpClientBuilder;
 import org.apache.http.client.config.RequestConfig;
 import org.slf4j.Logger;
@@ -14,7 +10,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
@@ -36,7 +31,7 @@ public class WebappController {
 
         // Randomize ID when none is set. More useful upstream responses
         Random rand = new Random();
-        String id = Integer.toString(rand.nextInt(7) + 1);
+        String id = Integer.toString(rand.nextInt(8) + 1);
         String pathQuery = ("/" + id);
 
         String nameEndpoint = getEndpoint("NAME", uri.getRequestUri().getScheme(), pathQuery);


### PR DESCRIPTION
*Description of changes:*

* Create a dedicated health check, so generated errors do not affect application health.
* Bubble up downstream errors to client
* Instrument outgoing HTTP calls automatically
* Generate random parameter passed to downstream name service
* Update X-Ray SDK to v1.3.1.
* Some code cleanup


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.